### PR TITLE
feat: Add export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,20 +20,20 @@ jobs:
       - name: Python test
         run: echo coming soon
 
-  mirror:
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    needs: [test, version]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # fetch all commits instead of just current one
-      - name: Create remote and push
-        env:
-          GITLAB_USER: ${{ secrets.GITLAB_USER }}
-          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
-        run: |
-          git remote add gitlab https://$GITLAB_USER:$GITLAB_TOKEN@gitlab.com/pagekey/semver.git
-          git remote remove origin
-          git push gitlab main
+  # mirror:
+  #   if: github.ref == 'refs/heads/main'
+  #   runs-on: ubuntu-latest
+  #   needs: [test, version]
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0  # fetch all commits instead of just current one
+  #     - name: Create remote and push
+  #       env:
+  #         GITLAB_USER: ${{ secrets.GITLAB_USER }}
+  #         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+  #       run: |
+  #         git remote add gitlab https://$GITLAB_USER:$GITLAB_TOKEN@gitlab.com/pagekey/semver.git
+  #         git remote remove origin
+  #         git push gitlab main

--- a/src/xylo/cli.py
+++ b/src/xylo/cli.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 import subprocess
 import sys
-import threading
 import click
 from cookiecutter.main import cookiecutter
 from xylo.config import load_config

--- a/src/xylo/cli.py
+++ b/src/xylo/cli.py
@@ -113,7 +113,25 @@ def run_frontend():
 
 @xylo.command()
 def build():
-    print("build")
+    clean_xylo()
+    build_frontend()
+
+
+def build_frontend():
+    config = load_config("xylo.yaml")
+    original_dir = os.getcwd()
+    generate_code()
+    os.chdir("xylo/frontend")
+    os.system("npm i")
+    os.system("npm run build")
+    os.system("npm link")
+    os.chdir(original_dir)
+    os.chdir(".xylo/frontend")
+    os.system("npm i")
+    os.system(f"npm link {config.name}-frontend")
+    os.system("npm run build")
+    os.system("mkdir ../../dist")
+    os.system("mv out ../../dist/frontend")
 
 
 @xylo.command()
@@ -131,7 +149,7 @@ def generate_code():
             f.write('"use client"\n')
             import_stmt = "import {" + function + "}" + f" from '{module}';\n"
             f.write(import_stmt)
-            f.write("export default function() {\n")
+            f.write(f"export default function {function}GeneratedPage()" + " {\n")
             f.write(f"    return <{function} />;\n")
             f.write("}\n")
     server_file = Path(".xylo") / "backend" / "server.py"

--- a/src/xylo/cli.py
+++ b/src/xylo/cli.py
@@ -114,13 +114,14 @@ def run_frontend():
 @xylo.command()
 def build():
     clean_xylo()
+    generate_code()
     build_frontend()
+    build_backend()
 
 
 def build_frontend():
     config = load_config("xylo.yaml")
     original_dir = os.getcwd()
-    generate_code()
     os.chdir("xylo/frontend")
     os.system("npm i")
     os.system("npm run build")
@@ -132,6 +133,15 @@ def build_frontend():
     os.system("npm run build")
     os.system("mkdir ../../dist")
     os.system("mv out ../../dist/frontend")
+    os.chdir(original_dir)
+
+
+def build_backend():
+    # config = load_config("xylo.yaml")
+    # original_dir = os.getcwd()
+    os.system("cp -r xylo/backend dist/backend")
+    os.system("rm -rf dist/backend/.venv")
+    os.system("cp .xylo/backend/server.py dist/backend/src")
 
 
 @xylo.command()

--- a/src/xylo/templates/{{cookiecutter.name}}/.ignore
+++ b/src/xylo/templates/{{cookiecutter.name}}/.ignore
@@ -1,1 +1,2 @@
 .xylo/
+dist/

--- a/src/xylo/templates/{{cookiecutter.name}}/.xylo/frontend/next.config.mjs
+++ b/src/xylo/templates/{{cookiecutter.name}}/.xylo/frontend/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+    output: 'export',
+};
 
 export default nextConfig;


### PR DESCRIPTION
Add ability to run `xylo build`, which creates an HTML export of the frontend and all the files needed to run the backend as a standalone Python app.